### PR TITLE
[FEAT] 카테고리 DataSource 구현 및 의존성 주입

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
+    id 'kotlin-kapt'
+    id 'dagger.hilt.android.plugin'
 }
 
 android {
@@ -54,6 +56,9 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
     implementation 'androidx.activity:activity-compose:1.3.1'
     implementation "androidx.navigation:navigation-compose:$rootProject.composeNavigationVersion"
+
+    implementation "com.google.dagger:hilt-android:2.38.1"
+    kapt "com.google.dagger:hilt-compiler:2.38.1"
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="com.woowahantechcamp.account_book">
 
     <application
+        android:name=".AccountBookApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/woowahantechcamp/account_book/AccountBookApplication.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/AccountBookApplication.kt
@@ -1,0 +1,9 @@
+package com.woowahantechcamp.account_book
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class AccountBookApplication: Application() {
+
+}

--- a/app/src/main/java/com/woowahantechcamp/account_book/MainActivity.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/MainActivity.kt
@@ -5,8 +5,10 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.*
-import androidx.compose.runtime.*
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.NavGraph.Companion.findStartDestination
@@ -20,7 +22,9 @@ import com.woowahantechcamp.account_book.ui.screen.main.AccountBookBottomNavigat
 import com.woowahantechcamp.account_book.ui.screen.main.AccountBookScreen
 import com.woowahantechcamp.account_book.ui.screen.setting.SettingScreen
 import com.woowahantechcamp.account_book.ui.theme.AccountbookTheme
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/woowahantechcamp/account_book/data/entity/CategoryEntity.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/data/entity/CategoryEntity.kt
@@ -1,0 +1,7 @@
+package com.woowahantechcamp.account_book.data.entity
+
+data class CategoryEntity(
+    val type: Int,
+    val title: String,
+    val color: String
+)

--- a/app/src/main/java/com/woowahantechcamp/account_book/data/repository/AccountBookDBHelper.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/data/repository/AccountBookDBHelper.kt
@@ -35,7 +35,7 @@ class AccountBookDBHelper(
                 "${BaseColumns._ID} INTEGER PRIMARY KEY, " +
                 "$COLUMN_NAME_TYPE INTEGER NOT NULL, " +
                 "$COLUMN_NAME_TITLE TEXT NOT NULL, " +
-                "$COLUMN_NAME_COLOR INTEGER NOT NULL)"
+                "$COLUMN_NAME_COLOR TEXT NOT NULL)"
     }
 
     override fun onCreate(db: SQLiteDatabase) {

--- a/app/src/main/java/com/woowahantechcamp/account_book/data/repository/category/CategoryDataSource.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/data/repository/category/CategoryDataSource.kt
@@ -1,0 +1,70 @@
+package com.woowahantechcamp.account_book.data.repository.category
+
+import android.content.ContentValues
+import com.woowahantechcamp.account_book.data.entity.CategoryEntity
+import com.woowahantechcamp.account_book.data.repository.AccountBookDBHelper
+import com.woowahantechcamp.account_book.data.repository.CategoryEntry
+import com.woowahantechcamp.account_book.util.Result
+import com.woowahantechcamp.account_book.util.query
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class CategoryDataSource @Inject constructor(
+    private val dbHelper: AccountBookDBHelper,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
+    suspend fun getAllCategory(): Result<List<CategoryEntity>> = withContext(ioDispatcher) {
+        try {
+            dbHelper.readableDatabase.use { db ->
+                val projection = arrayOf(
+                    CategoryEntry.COLUMN_NAME_TYPE,
+                    CategoryEntry.COLUMN_NAME_TITLE,
+                    CategoryEntry.COLUMN_NAME_COLOR
+                )
+
+                val cursor = db.query(
+                    tableName = CategoryEntry.TABLE_NAME,
+                    projection = projection
+                )
+
+                val items = mutableListOf<CategoryEntity>()
+
+                with(cursor) {
+                    while (moveToNext()) {
+                        val type = getInt(getColumnIndexOrThrow(CategoryEntry.COLUMN_NAME_TYPE))
+                        val title =
+                            getString(getColumnIndexOrThrow(CategoryEntry.COLUMN_NAME_TITLE))
+                        val color =
+                            getString(getColumnIndexOrThrow(CategoryEntry.COLUMN_NAME_COLOR))
+
+                        items.add(CategoryEntity(type, title, color))
+                    }
+                }
+                cursor.close()
+                Result.Success(data = items)
+            }
+        } catch (e: Exception) {
+            Result.Error(e.message ?: "fail")
+        }
+    }
+
+    suspend fun insertCategory(item: CategoryEntity): Result<Long> = withContext(ioDispatcher) {
+        try {
+            dbHelper.writableDatabase.use { db ->
+                val values = ContentValues().apply {
+                    put(CategoryEntry.COLUMN_NAME_TYPE, item.type)
+                    put(CategoryEntry.COLUMN_NAME_TITLE, item.title)
+                    put(CategoryEntry.COLUMN_NAME_COLOR, item.color)
+                }
+
+                val newRowId = db.insert(CategoryEntry.TABLE_NAME, null, values)
+
+                Result.Success(data = newRowId)
+            }
+        } catch (e: Exception) {
+            Result.Error(e.message ?: "fail")
+        }
+    }
+}

--- a/app/src/main/java/com/woowahantechcamp/account_book/data/repository/category/CategoryRepository.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/data/repository/category/CategoryRepository.kt
@@ -1,0 +1,25 @@
+package com.woowahantechcamp.account_book.data.repository.category
+
+import com.woowahantechcamp.account_book.data.entity.CategoryEntity
+import com.woowahantechcamp.account_book.util.Result
+import com.woowahantechcamp.account_book.util.UiState
+import javax.inject.Inject
+
+class CategoryRepository @Inject constructor(
+    private val categoryDataSource: CategoryDataSource
+) {
+    suspend fun getAllCategory(): UiState<List<CategoryEntity>> {
+        return when (val result = categoryDataSource.getAllCategory()) {
+            is Result.Success -> {
+                UiState.Success(data = result.data)
+            }
+            is Result.Error -> {
+                UiState.Error(result.exception)
+            }
+        }
+    }
+
+    suspend fun addCategory(type: Int, title: String, color: String) {
+        categoryDataSource.insertCategory(CategoryEntity(type, title, color))
+    }
+}

--- a/app/src/main/java/com/woowahantechcamp/account_book/di/AppModule.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/di/AppModule.kt
@@ -1,0 +1,39 @@
+package com.woowahantechcamp.account_book.di
+
+import android.content.Context
+import com.woowahantechcamp.account_book.data.repository.AccountBookDBHelper
+import com.woowahantechcamp.account_book.data.repository.category.CategoryRepository
+import com.woowahantechcamp.account_book.data.repository.category.CategoryDataSource
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppModule {
+
+    @Singleton
+    @Provides
+    fun provideDataBase(@ApplicationContext context: Context): AccountBookDBHelper =
+        AccountBookDBHelper(context)
+
+    @Provides
+    fun provideIoDispatcher(): CoroutineDispatcher = Dispatchers.IO
+
+    @Singleton
+    @Provides
+    fun provideCategoryDataSource(
+        dbHelper: AccountBookDBHelper,
+        ioDispatcher: CoroutineDispatcher
+    ) = CategoryDataSource(dbHelper, ioDispatcher)
+
+    @Singleton
+    @Provides
+    fun provideCategoryRepository(categoryDataSource: CategoryDataSource) =
+        CategoryRepository(categoryDataSource)
+}

--- a/app/src/main/java/com/woowahantechcamp/account_book/util/Extensions.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/util/Extensions.kt
@@ -1,0 +1,13 @@
+package com.woowahantechcamp.account_book.util
+
+import android.database.Cursor
+import android.database.sqlite.SQLiteDatabase
+import android.provider.BaseColumns
+
+fun SQLiteDatabase.query(
+    tableName: String,
+    projection: Array<String>,
+    selection: String? = null,
+    selectionArgs: Array<String>? = null,
+    order: String = BaseColumns._ID
+): Cursor = this.query(tableName, projection, selection, selectionArgs, null, null, order)

--- a/app/src/main/java/com/woowahantechcamp/account_book/util/Result.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/util/Result.kt
@@ -1,0 +1,7 @@
+package com.woowahantechcamp.account_book.util
+
+sealed class Result<out R> {
+    data class Success<out T>(val data: T) : Result<T>()
+    data class Error(val exception: String) : Result<Nothing>()
+}
+

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,9 @@ buildscript {
         compose_version = '1.1.1'
         composeNavigationVersion = '2.5.0'
     }
+    dependencies {
+        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.38.1'
+    }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id 'com.android.application' version '7.2.1' apply false


### PR DESCRIPTION
## Screen Type
- 공통

## Description
- close #9 
- Hilt 적용
- 카테고리 삽입, 조회 구현
- DataSource는 SQLiteDatabase에 직접 접근, Repository는 DataSource의 결과를 받아 가공