### PR TITLE
[FEAT] 설정화면 네비게이션 처리

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,11 +15,10 @@
         android:theme="@style/Theme.Accountbook"
         tools:targetApi="31">
         <activity
-            android:name=".MainActivity"
+            android:name=".ui.MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.Accountbook"
-            android:windowSoftInputMode="adjustResize">
+            android:theme="@style/Theme.Accountbook">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/woowahantechcamp/account_book/data/repository/AccountBookRepository.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/data/repository/AccountBookRepository.kt
@@ -26,6 +26,7 @@ class AccountBookRepository @Inject constructor(
 
             Result.Success(data = result.map {
                 SettingItem.CategoryItem(
+                    id = it.categoryId,
                     type = if (it.type == 1) Type.INCOME else Type.EXPENSES,
                     title = it.title,
                     color = Color(it.color.toColorInt())

--- a/app/src/main/java/com/woowahantechcamp/account_book/ui/AccountBookApp.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/ui/AccountBookApp.kt
@@ -1,8 +1,5 @@
-package com.woowahantechcamp.account_book
+package com.woowahantechcamp.account_book.ui
 
-import android.os.Bundle
-import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Scaffold
@@ -10,40 +7,21 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.*
 import androidx.navigation.NavGraph.Companion.findStartDestination
-import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import com.woowahantechcamp.account_book.data.repository.AccountBookDBHelper
 import com.woowahantechcamp.account_book.ui.screen.history.HistoryScreen
 import com.woowahantechcamp.account_book.ui.screen.main.AccountBookBottomNavigation
 import com.woowahantechcamp.account_book.ui.screen.main.AccountBookScreen
+import com.woowahantechcamp.account_book.ui.screen.setting.SettingDetail
+import com.woowahantechcamp.account_book.ui.screen.setting.SettingType
 import com.woowahantechcamp.account_book.ui.screen.setting.SettingScreen
+import com.woowahantechcamp.account_book.ui.screen.setting.SettingViewModel
 import com.woowahantechcamp.account_book.ui.theme.AccountbookTheme
-import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
-
-@AndroidEntryPoint
-class MainActivity : ComponentActivity() {
-
-    @Inject lateinit var dbHelper: AccountBookDBHelper
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setContent {
-            AccountBookApp()
-        }
-    }
-
-    override fun onDestroy() {
-        dbHelper.close()
-        super.onDestroy()
-    }
-}
 
 @Composable
 fun AccountBookApp() {
@@ -79,7 +57,41 @@ fun AccountBookApp() {
                     Text(AccountBookScreen.Graph.route)
                 }
                 composable(route = AccountBookScreen.Setting.route) {
-                    SettingScreen(hiltViewModel())
+                    SettingScreen(
+                        hiltViewModel<SettingViewModel>(),
+                        onItemClicked = { type, id ->
+                            navController.navigate(route = "${MainDestinations.SETTING_DETAIL_ROUTE}/$type/$id")
+                        },
+                        onAddClick = {
+                            navController.navigate(route = "${MainDestinations.SETTING_DETAIL_ROUTE}/add/$it")
+                        }
+                    )
+                }
+                composable(
+                    route = "${MainDestinations.SETTING_DETAIL_ROUTE}/{type}/{id}",
+                    arguments = listOf(
+                        navArgument("type") { type = NavType.EnumType(SettingType::class.java) },
+                        navArgument("id") { type = NavType.IntType }
+                    )
+                ) { backStackEntry ->
+                    val type = backStackEntry.arguments?.get("type") as SettingType
+                    val id = backStackEntry.arguments?.get("id") as Int // 아이템 조회시 필요 TODO
+
+                    SettingDetail(title = type.addTitle, type = type) {
+                        navController.navigateUp()
+                    }
+                }
+                composable(
+                    route = "${MainDestinations.SETTING_DETAIL_ROUTE}/add/{type}",
+                    arguments = listOf(navArgument("type") {
+                        type = NavType.EnumType(SettingType::class.java)
+                    })
+                ) { backStackEntry ->
+                    val type = backStackEntry.arguments?.get("type") as SettingType
+
+                    SettingDetail(title = type.addTitle, type = type) {
+                        navController.navigateUp()
+                    }
                 }
             }
         }
@@ -96,11 +108,3 @@ fun NavHostController.navigateSingleTopTo(route: String) =
         launchSingleTop = true
         restoreState = true
     }
-
-@Preview(showBackground = true)
-@Composable
-fun DefaultPreview() {
-    AccountbookTheme {
-        AccountBookApp()
-    }
-}

--- a/app/src/main/java/com/woowahantechcamp/account_book/ui/AppDestinations.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/ui/AppDestinations.kt
@@ -1,0 +1,7 @@
+package com.woowahantechcamp.account_book.ui
+
+object MainDestinations {
+    const val HOME_ROUTE = "home"
+    const val HISTORY_DETAIL_ROUTE = "historyDetail"
+    const val SETTING_DETAIL_ROUTE = "settingDetail"
+}

--- a/app/src/main/java/com/woowahantechcamp/account_book/ui/MainActivity.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/ui/MainActivity.kt
@@ -1,0 +1,37 @@
+package com.woowahantechcamp.account_book.ui
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.woowahantechcamp.account_book.data.repository.AccountBookDBHelper
+import com.woowahantechcamp.account_book.ui.theme.AccountbookTheme
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class MainActivity : ComponentActivity() {
+
+    @Inject lateinit var dbHelper: AccountBookDBHelper
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            AccountBookApp()
+        }
+    }
+
+    override fun onDestroy() {
+        dbHelper.close()
+        super.onDestroy()
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun DefaultPreview() {
+    AccountbookTheme {
+        AccountBookApp()
+    }
+}

--- a/app/src/main/java/com/woowahantechcamp/account_book/ui/model/setting/SettingItem.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/ui/model/setting/SettingItem.kt
@@ -3,15 +3,18 @@ package com.woowahantechcamp.account_book.ui.model.setting
 import androidx.compose.ui.graphics.Color
 
 sealed class SettingItem(
+    open val id: Int,
     open val title: String
 ) {
     data class TextItem(
+        override val id: Int,
         override val title: String
-    ) : SettingItem(title)
+    ) : SettingItem(id, title)
 
     data class CategoryItem(
+        override val id: Int,
         override val title: String,
         val type: Type,
         val color: Color
-    ) : SettingItem(title)
+    ) : SettingItem(id, title)
 }

--- a/app/src/main/java/com/woowahantechcamp/account_book/ui/screen/setting/SettingDetail.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/ui/screen/setting/SettingDetail.kt
@@ -10,17 +10,15 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import com.woowahantechcamp.account_book.ui.component.*
-import com.woowahantechcamp.account_book.ui.model.setting.Type
-import com.woowahantechcamp.account_book.ui.theme.AccountbookTheme
 import com.woowahantechcamp.account_book.util.expenseColorList
 import com.woowahantechcamp.account_book.util.incomeColorList
 
 @Composable
 fun SettingDetail(
     title: String,
-    type: Type?
+    type: SettingType?,
+    onUpPressed: () -> Unit
 ) {
     val text = rememberSaveable { mutableStateOf("") }
     val selectedColorIndex = rememberSaveable { mutableStateOf(0) }
@@ -28,7 +26,7 @@ fun SettingDetail(
     Scaffold(
         topBar = {
             TopAppBarWithUpButton(title = title) {
-                // TODO
+                onUpPressed()
             }
         }
     ) {
@@ -41,11 +39,11 @@ fun SettingDetail(
                 InputField(title = "이름") {
                     PlainTextInputField(text.value) { text.value = it }
                 }
-                if (type != null) {
+                if (type != SettingType.PAYMENT) {
                     ColorPalette(
                         modifier = Modifier,
                         selectedIndex = selectedColorIndex.value,
-                        colorList = if (type == Type.INCOME) incomeColorList
+                        colorList = if (type == SettingType.INCOME) incomeColorList
                         else expenseColorList
                     ) {
                         selectedColorIndex.value = it
@@ -60,16 +58,6 @@ fun SettingDetail(
             ) {
                 // TODO
             }
-        }
-    }
-}
-
-@Preview
-@Composable
-fun SettingDetailPreview() {
-    AccountbookTheme {
-        Scaffold {
-            SettingDetail(title = "수입 카테고리 추가", Type.INCOME)
         }
     }
 }

--- a/app/src/main/java/com/woowahantechcamp/account_book/ui/screen/setting/SettingScreen.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/ui/screen/setting/SettingScreen.kt
@@ -23,10 +23,15 @@ import com.woowahantechcamp.account_book.ui.component.DividerPurple40
 import com.woowahantechcamp.account_book.ui.model.setting.SettingItem
 import com.woowahantechcamp.account_book.ui.model.setting.SettingItem.CategoryItem
 import com.woowahantechcamp.account_book.ui.model.setting.SettingItem.TextItem
+import com.woowahantechcamp.account_book.ui.model.setting.Type
 import com.woowahantechcamp.account_book.ui.theme.LightPurple
 
 @Composable
-fun SettingScreen(viewModel: SettingViewModel) {
+fun SettingScreen(
+    viewModel: SettingViewModel,
+    onItemClicked: (SettingType, Int) -> Unit,
+    onAddClick: (SettingType) -> Unit
+) {
     val payments = SettingType.PAYMENT to listOf(
         TextItem(1, "현대카드"),
         TextItem(2, "카카오뱅크 체크카드")
@@ -57,8 +62,23 @@ fun SettingScreen(viewModel: SettingViewModel) {
         DividerPrimary()
         SettingList(
             grouped = mapOf(payments, expenses, incomes),
-            onItemClick = {},
-            onAddClick = {}
+            onItemClick = {
+                when (it) {
+                    is TextItem -> {
+                        onItemClicked(SettingType.PAYMENT, it.id)
+                    }
+                    is CategoryItem -> {
+                        if (it.type == Type.INCOME) {
+                            onItemClicked(SettingType.INCOME, it.id)
+                        } else {
+                            onItemClicked(SettingType.EXPENSE, it.id)
+                        }
+                    }
+                }
+            },
+            onAddClick = {
+                onAddClick(it)
+            }
         )
     }
 }

--- a/app/src/main/java/com/woowahantechcamp/account_book/ui/screen/setting/SettingScreen.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/ui/screen/setting/SettingScreen.kt
@@ -14,30 +14,28 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.woowahantechcamp.account_book.R
 import com.woowahantechcamp.account_book.ui.component.CategoryTag
+import com.woowahantechcamp.account_book.ui.component.DividerPrimary
+import com.woowahantechcamp.account_book.ui.component.DividerPurple40
 import com.woowahantechcamp.account_book.ui.model.setting.SettingItem
-import com.woowahantechcamp.account_book.ui.model.setting.SettingItem.TextItem
 import com.woowahantechcamp.account_book.ui.model.setting.SettingItem.CategoryItem
-import com.woowahantechcamp.account_book.ui.theme.AccountbookTheme
+import com.woowahantechcamp.account_book.ui.model.setting.SettingItem.TextItem
 import com.woowahantechcamp.account_book.ui.theme.LightPurple
-import com.woowahantechcamp.account_book.ui.theme.Purple
-import com.woowahantechcamp.account_book.ui.theme.Purple40
 
 @Composable
 fun SettingScreen(viewModel: SettingViewModel) {
-    val payments = "결제수단" to listOf(
-        TextItem("현대카드"),
-        TextItem("카카오뱅크 체크카드")
+    val payments = SettingType.PAYMENT to listOf(
+        TextItem(1, "현대카드"),
+        TextItem(2, "카카오뱅크 체크카드")
     )
     val incomeCategory: List<CategoryItem> by viewModel.incomeCategory.observeAsState(listOf())
     val expensesCategory: List<CategoryItem> by viewModel.expenseCategory.observeAsState(listOf())
 
-    val incomes = "수입 카테고리" to incomeCategory
-    val expenses = "지출 카테고리" to expensesCategory
+    val incomes = SettingType.INCOME to incomeCategory
+    val expenses = SettingType.EXPENSE to expensesCategory
 
     Scaffold(
         topBar = {
@@ -56,15 +54,40 @@ fun SettingScreen(viewModel: SettingViewModel) {
             }
         }
     ) {
-        Divider(
-            color = MaterialTheme.colors.primary,
-            thickness = 1.dp
-        )
+        DividerPrimary()
         SettingList(
             grouped = mapOf(payments, expenses, incomes),
             onItemClick = {},
             onAddClick = {}
         )
+    }
+}
+
+@Composable
+fun SettingList(
+    grouped: Map<SettingType, List<SettingItem>>,
+    onItemClick: (SettingItem) -> Unit,
+    onAddClick: (SettingType) -> Unit
+) {
+    LazyColumn {
+        grouped.forEach { (type, list) ->
+            item {
+                Header(title = type.plainTitle)
+            }
+            items(list) { item ->
+                Body(
+                    item = item,
+                    onItemClick = onItemClick
+                )
+            }
+            item {
+                Footer(
+                    type = type,
+                    onAddClick = onAddClick
+                )
+                DividerPrimary()
+            }
+        }
     }
 }
 
@@ -84,17 +107,14 @@ fun Header(title: String) {
 @Composable
 fun Body(
     item: SettingItem,
-    onItemClick: (String) -> Unit
+    onItemClick: (SettingItem) -> Unit
 ) {
     Column(modifier = Modifier
         .fillMaxWidth()
-        .clickable { onItemClick(item.title) }
+        .clickable { onItemClick(item) }
         .padding(horizontal = 16.dp)
     ) {
-        Divider(
-            color = Purple40,
-            thickness = 1.dp
-        )
+        DividerPurple40()
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -123,17 +143,14 @@ fun Body(
 }
 
 @Composable
-fun Footer(title: String, onAddClick: () -> Unit) {
+fun Footer(type: SettingType, onAddClick: (SettingType) -> Unit) {
     Column(modifier = Modifier
-        .clickable { onAddClick() }
+        .clickable { onAddClick(type) }
         .padding(horizontal = 16.dp)) {
-        Divider(
-            color = Purple40,
-            thickness = 1.dp
-        )
+        DividerPurple40()
         Row(modifier = Modifier.padding(0.dp, 12.dp)) {
             Text(
-                text = "$title 추가하기",
+                text = type.addTitle,
                 color = MaterialTheme.colors.primary,
                 fontSize = 16.sp,
                 fontWeight = FontWeight.Bold,
@@ -151,33 +168,3 @@ fun Footer(title: String, onAddClick: () -> Unit) {
     }
 }
 
-@Composable
-fun SettingList(
-    grouped: Map<String, List<SettingItem>>,
-    onItemClick: (String) -> Unit,
-    onAddClick: () -> Unit
-) {
-    LazyColumn {
-        grouped.forEach { (title, list) ->
-            item {
-                Header(title = title)
-            }
-            items(list) { item ->
-                Body(
-                    item = item,
-                    onItemClick = onItemClick
-                )
-            }
-            item {
-                Footer(
-                    title = title,
-                    onAddClick = onAddClick
-                )
-                Divider(
-                    color = Purple,
-                    thickness = 1.dp
-                )
-            }
-        }
-    }
-}

--- a/app/src/main/java/com/woowahantechcamp/account_book/ui/screen/setting/SettingType.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/ui/screen/setting/SettingType.kt
@@ -1,0 +1,10 @@
+package com.woowahantechcamp.account_book.ui.screen.setting
+
+enum class SettingType(
+    val plainTitle: String,
+    val addTitle: String
+) {
+    PAYMENT("결제수단", "결제수단 추가하기"),
+    INCOME("수입", "수입 카테고리 추가"),
+    EXPENSE("지출", "지출 카테고리 추가")
+}


### PR DESCRIPTION
## Screen Type
- 설정화면

## Description
- close #26 
- 설정화면에서 리스트 아이템이나 추가 버튼을 누르면 타입에 맞는 등록화면으로 이동
- 기존 아이템의 경우 parcelable로 argument에 전달하려 했으나 이 부분은 아직 해결하지 못해 id 값을 전달
