### PR TITLE
[FEAT] 상단바에서 월 변경 기능 구현

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,6 +63,8 @@ dependencies {
     implementation "androidx.compose.runtime:runtime-livedata:1.3.0-alpha01"
     implementation 'androidx.hilt:hilt-navigation-compose:1.0.0'
 
+    implementation "com.chargemap.compose:numberpicker:1.0.3"
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/src/main/java/com/woowahantechcamp/account_book/ui/component/DatePickerDialog.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/ui/component/DatePickerDialog.kt
@@ -1,0 +1,72 @@
+package com.woowahantechcamp.account_book.ui.component
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.chargemap.compose.numberpicker.NumberPicker
+import com.woowahantechcamp.account_book.ui.theme.White
+import java.time.LocalDate
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun DatePickerDialog(
+    year: Int,
+    month: Int,
+    onDateChanged: (Int, Int) -> Unit,
+    onDismissRequest: () -> Unit
+) {
+    val today = LocalDate.now()
+    var yearValue by remember { mutableStateOf(year) }
+    var monthValue by remember { mutableStateOf(month) }
+
+    Dialog(onDismissRequest = { onDismissRequest() }) {
+        Surface(
+            color = White,
+            shape = RoundedCornerShape(10.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(width = 256.dp, height = 200.dp)
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.align(Alignment.Center)
+                ) {
+                    NumberPicker(
+                        value = yearValue,
+                        range = 2021..today.year,
+                        onValueChange = {
+                            yearValue = it
+                        }
+                    )
+                    Text(text = "년")
+                    NumberPicker(
+                        value = monthValue,
+                        range = if (yearValue < today.year) 1..12 else 1..today.monthValue,
+                        onValueChange = { monthValue = it }
+                    )
+                    Text(text = "월")
+                }
+                TextButton(
+                    onClick = {
+                        onDateChanged(yearValue, monthValue)
+                    },
+                    modifier = Modifier.align(Alignment.BottomEnd)
+                ) {
+                    Text(text = "확인")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/woowahantechcamp/account_book/ui/component/TopAppBar.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/ui/component/TopAppBar.kt
@@ -53,6 +53,7 @@ fun TopAppBarWithUpButton(
 fun TopAppBarWithMonth(
     year: Int,
     month: Int,
+    onDateClick: () -> Unit,
     onPrevMonthClick: () -> Unit,
     onNextMonthClick: () -> Unit
 ) {
@@ -69,13 +70,17 @@ fun TopAppBarWithMonth(
                     tint = MaterialTheme.colors.primary
                 )
             }
-            Text(
-                text = "${year}년 ${month}월",
-                modifier = Modifier.weight(1f),
-                textAlign = TextAlign.Center,
-                fontSize = 18.sp,
-                color = MaterialTheme.colors.primary
-            )
+            TextButton(
+                onClick = { onDateClick() },
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(
+                    text = "${year}년 ${month}월",
+                    textAlign = TextAlign.Center,
+                    fontSize = 18.sp,
+                    color = MaterialTheme.colors.primary
+                )
+            }
             IconButton(onClick = { onNextMonthClick() }) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_right),

--- a/app/src/main/java/com/woowahantechcamp/account_book/ui/screen/graph/GraphScreen.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/ui/screen/graph/GraphScreen.kt
@@ -9,6 +9,9 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -30,8 +33,11 @@ fun GraphScreen(
 ) {
     val year = mainViewModel.currentDate.value.year
     val month = mainViewModel.currentDate.value.monthValue
+    val isDatePickerDialogVisible = remember { mutableStateOf(false) }
 
-    viewModel.fetchData(year, month)
+    LaunchedEffect(key1 = year, key2 = month){
+        viewModel.fetchData(year, month)
+    }
 
     val list = viewModel.statistics.value
     val sumOfExpense = list.sumOf { it.sum }
@@ -41,6 +47,7 @@ fun GraphScreen(
             TopAppBarWithMonth(
                 year = year,
                 month = month,
+                onDateClick = { isDatePickerDialogVisible.value = true },
                 onPrevMonthClick = {
                     mainViewModel.moveToPrevMonth()
                     viewModel.fetchData(
@@ -58,6 +65,18 @@ fun GraphScreen(
             )
         }
     ) {
+        if (isDatePickerDialogVisible.value) {
+            DatePickerDialog(
+                year = year,
+                month = month,
+                onDateChanged = { newYear, newMonth ->
+                    mainViewModel.setDate(newYear, newMonth)
+                    isDatePickerDialogVisible.value = false
+                },
+                onDismissRequest = { isDatePickerDialogVisible.value = false }
+            )
+        }
+
         Column(modifier = Modifier.fillMaxSize()) {
             GraphHeader(sumOfExpense = sumOfExpense)
             DividerPurple40()

--- a/app/src/main/java/com/woowahantechcamp/account_book/ui/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/ui/screen/history/HistoryScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -23,10 +24,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.woowahantechcamp.account_book.R
-import com.woowahantechcamp.account_book.ui.component.CategoryTag
-import com.woowahantechcamp.account_book.ui.component.FilterButton
-import com.woowahantechcamp.account_book.ui.component.TopAppBarForEditMode
-import com.woowahantechcamp.account_book.ui.component.TopAppBarWithMonth
+import com.woowahantechcamp.account_book.ui.component.*
 import com.woowahantechcamp.account_book.ui.model.HistoryModel
 import com.woowahantechcamp.account_book.ui.model.Type
 import com.woowahantechcamp.account_book.ui.screen.main.MainViewModel
@@ -45,6 +43,8 @@ fun HistoryScreen(
 ) {
     val year = mainViewModel.currentDate.value.year
     val month = mainViewModel.currentDate.value.monthValue
+
+    val isDatePickerDialogVisible = remember { mutableStateOf(false) }
 
     viewModel.fetchData(year, month)
 
@@ -80,6 +80,7 @@ fun HistoryScreen(
                 TopAppBarWithMonth(
                     year = year,
                     month = month,
+                    onDateClick = { isDatePickerDialogVisible.value = true },
                     onPrevMonthClick = {
                         mainViewModel.moveToPrevMonth()
                         viewModel.fetchData(
@@ -116,6 +117,18 @@ fun HistoryScreen(
             }
         }
     ) {
+        if (isDatePickerDialogVisible.value) {
+            DatePickerDialog(
+                year = year,
+                month = month,
+                onDateChanged = { newYear, newMonth ->
+                    mainViewModel.setDate(newYear, newMonth)
+                    isDatePickerDialogVisible.value = false
+                },
+                onDismissRequest = { isDatePickerDialogVisible.value = false }
+            )
+        }
+
         Column {
             FilterButton(
                 enabled = isEditMode.not(),

--- a/app/src/main/java/com/woowahantechcamp/account_book/ui/screen/main/MainViewModel.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/ui/screen/main/MainViewModel.kt
@@ -30,4 +30,8 @@ class MainViewModel @Inject constructor() : ViewModel() {
             _currentDate.value = prevMonth
         }
     }
+
+    fun setDate(year: Int, month: Int) {
+        _currentDate.value = LocalDate.of(year, month, 1)
+    }
 }


### PR DESCRIPTION
## Screen Type
- 공통

## Description
- close #51 
- 상단바의 현재 표시되는 월 텍스트를 누르면 월을 변경할 수 있는 다이얼로그 표시
- 조회 가능 범위는 2021년 1월부터 현재 시점까지