### PR TITLE
[FIX] 내역 등록/수정 화면 버그 수정

### DIFF
--- a/app/src/main/java/com/woowahantechcamp/account_book/ui/screen/history/AddEditHistoryViewModel.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/ui/screen/history/AddEditHistoryViewModel.kt
@@ -38,6 +38,7 @@ class AddEditHistoryViewModel @Inject constructor(
     fun setType(type: Type) {
         _type.value = type
         _paymentId.value = -1
+        paymentName.value = ""
         _categoryId.value = -1
         _categoryName.value = ""
     }
@@ -98,7 +99,11 @@ class AddEditHistoryViewModel @Inject constructor(
                 _categoryId.value = history.categoryId
                 _categoryName.value = history.category
                 _content.value = history.title
-                if (_type.value == Type.EXPENSES) _paymentId.value = history.paymentId!!
+
+                if (_type.value == Type.EXPENSES) {
+                    _paymentId.value = history.paymentId!!
+                    _paymentName.value = history.payment!!
+                }
             }
         }
     }

--- a/app/src/main/java/com/woowahantechcamp/account_book/ui/screen/history/HistoryDetail.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/ui/screen/history/HistoryDetail.kt
@@ -37,10 +37,8 @@ fun HistoryDetail(
         viewModel.getAllCategoryItem()
         viewModel.getAllPaymentItem()
 
-        if (id > 0) {
-            viewModel.setType(type)
-            viewModel.getHistoryItem(id)
-        }
+        if (type == Type.EXPENSES) viewModel.setType(type)
+        if (id > 0) viewModel.getHistoryItem(id)
     }
 
     val selectedType = viewModel.type.value


### PR DESCRIPTION
## Screen Type
- 내역 등록

## Description
- close #56 
- 내역 등록/수정 화면 버그 수정

## Memo
지출 탭 선택 후 새로운 내역 등록
- id가 0보다 큰 경우만 타입을 설정하니까 지출탭이 선택된 채로 등록화면 진입시에도 기본 값인 수입 탭이 선택되고 있었음

지출 상세화면 결제수단
- paymentId 만 설정하고 paymentName을 설정하지 않았음
