### PR TITLE
[FIX] 딥링크 바텀 네비게이션 선택 상태 수정

### DIFF
--- a/app/src/main/java/com/woowahantechcamp/account_book/ui/screen/main/AccountBookBottomNavigation.kt
+++ b/app/src/main/java/com/woowahantechcamp/account_book/ui/screen/main/AccountBookBottomNavigation.kt
@@ -36,7 +36,7 @@ fun AccountBookBottomNavigation(
                 },
                 selectedContentColor = MaterialTheme.colors.onPrimary,
                 unselectedContentColor = White50,
-                selected = currentScreen == item.route,
+                selected = currentScreen?.startsWith(item.route) ?: false,
                 onClick = { onTabSelected(item) }
             )
         }


### PR DESCRIPTION
## Screen Type
- 공통

## Description
- route의 prefix로 선택 상태 표시
- ex. 내역 등록 화면에서 내역 탭 선택 상태 유지
